### PR TITLE
Allow customization for faucet hostname

### DIFF
--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -8,7 +8,7 @@ server {
 server {
     listen              443 ssl default_server;
     listen              [::]:443 ssl default_server ;
-    server_name faucet.testnet.z.cash;
+    server_name _;
     ssl_certificate /ssl/faucet.testnet.z.cash.pem;
     ssl_certificate_key /ssl/faucet.testnet.z.cash-private.key;
 

--- a/zfaucet/settings.py
+++ b/zfaucet/settings.py
@@ -41,6 +41,8 @@ DEBUG = ENVIRONMENT == 'dev'
 
 # production
 ALLOWED_HOSTS = ['faucet.testnet.z.cash', '127.0.0.1']
+if os.getenv('ZFAUCET_HOSTNAME'):
+    ALLOWED_HOSTS.append(os.getenv('ZFAUCET_HOSTNAME'))
 
 # Application definition
 


### PR DESCRIPTION
Django requires a list of allowed hostnames, and regexes aren't allowed.

This change allows runtime customization of the `ALLOWED_HOSTS` value.