### PR TITLE
Reverting previous change to save actions on t-addresses only

### DIFF
--- a/faucet/views.py
+++ b/faucet/views.py
@@ -77,7 +77,6 @@ def index(request):
                     drip.save()
                     msg = "Sent! txid: {0}. View your transaction on the testnet explorer.".format(tx)
                     return render(request, 'faucet/faucet.html', {'version':version,'balance':balance,'difficulty':difficulty,'height':height, 'payouts':payouts, 'flash':True, 'message':msg})
-
             # Sapling address
             elif len(address) == len('ztestsapling1603ydy9hg79lv5sv9pm5hn95cngfv4qpd6y54a8wkyejn72jl30a4pfhw8u00p93mu4nj6qxsqg'):
                 print('Received a Sapling address')
@@ -123,7 +122,5 @@ def index(request):
             print('ERROR: unknow address format')
             msg = "Issue sending transaction.  Is your address correct?"
             return render(request, 'faucet/faucet.html', {'version':version,'balance':balance,'difficulty':difficulty,'height':height, 'payouts':payouts, 'flash':True, 'message':msg})
-
-
 
     return render(request, 'faucet/faucet.html', {'version':version,'balance':balance,'difficulty':difficulty,'height':height, 'payouts':payouts, 'flash':False, 'message':""})

--- a/faucet/views.py
+++ b/faucet/views.py
@@ -71,8 +71,13 @@ def index(request):
             if len(address) == len('tmKBPqa8qqKA7vrGq1AaXHSAr9vqa3GczzK'):
                 tx = zd.sendtoaddress(address, 1.0)
                 if len(tx) == len('2ac64e297e3910e7ffda7210e7aa2463fe2ec5f69dfe7fdf0b4b9be138a9bfb8'):
+                    #Save Drip.
+                    print('Saving Drip for {address} transaction {txid} from ip: {ip}'.format(address=address,txid=tx,ip=ip))
+                    drip = Drip(address=address,txid=tx,ip=ip)
+                    drip.save()
                     msg = "Sent! txid: {0}. View your transaction on the testnet explorer.".format(tx)
                     return render(request, 'faucet/faucet.html', {'version':version,'balance':balance,'difficulty':difficulty,'height':height, 'payouts':payouts, 'flash':True, 'message':msg})
+
             # Sapling address
             elif len(address) == len('ztestsapling1603ydy9hg79lv5sv9pm5hn95cngfv4qpd6y54a8wkyejn72jl30a4pfhw8u00p93mu4nj6qxsqg'):
                 print('Received a Sapling address')
@@ -119,9 +124,6 @@ def index(request):
             msg = "Issue sending transaction.  Is your address correct?"
             return render(request, 'faucet/faucet.html', {'version':version,'balance':balance,'difficulty':difficulty,'height':height, 'payouts':payouts, 'flash':True, 'message':msg})
 
-        #Save Drip.
-        print('Sacing Drip for {address} transaction {txid} from ip: {ip}'.format(address=address,txid=tx,ip=ip))
-        drip = Drip(address=address,txid=tx,ip=ip)
-        drip.save()
+
 
     return render(request, 'faucet/faucet.html', {'version':version,'balance':balance,'difficulty':difficulty,'height':height, 'payouts':payouts, 'flash':False, 'message':""})


### PR DESCRIPTION
Reverting this change https://github.com/zcash-hackworks/zfaucet/commit/8417ace5baaa1e465339a11da535d99b13e65b6f#diff-fa6738240f7cc0c2feabd4ae524824fc

Fails because non t-address transactions don't currently provide the correct info.